### PR TITLE
cache all should return only keys

### DIFF
--- a/lib/nebulex/adapters/mnesia.ex
+++ b/lib/nebulex/adapters/mnesia.ex
@@ -181,7 +181,7 @@ defmodule Nebulex.Adapters.Mnesia do
   @impl Nebulex.Adapter.Queryable
   def execute(_adapter_meta, :all, nil, _opts) do
     Table.all_records()
-    |> Enum.map(fn {_table, _key, value, _touched, _ttl} -> value end)
+    |> Enum.map(fn {_table, key, _value, _touched, _ttl} -> key end)
   end
 
   @impl Nebulex.Adapter.Queryable


### PR DESCRIPTION
Cache.all should return only keys, right now it is returning the value