### PR TITLE
Add TTL removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ defmodule MyApp.Cache do
 end
 ```
 
+The adapter will check for expired keys (where ttl has been reached) every  minute by default,
+to change the frequency of this check you can add to your config file:
+
+```elixir
+config :my_app, MyApp.Cache,
+    ttl: 300_000
+```
+
+This will check every 5 minutes and delete the expired cache keys
+
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at <https://hexdocs.pm/nebulex_mnesia_adapter>.

--- a/lib/nebulex/adapters/mnesia.ex
+++ b/lib/nebulex/adapters/mnesia.ex
@@ -14,7 +14,9 @@ defmodule Nebulex.Adapters.Mnesia do
   def init(opts) do
     children = [
       Supervisor.child_spec(ClusterCheck, id: Mnesia.ClusterCheck),
-      Supervisor.child_spec({Nebulex.Adapters.Mnesia.ExpirationCheck, opts}, id: Nebulex.Adapters.Mnesia.ExpirationCheck)
+      Supervisor.child_spec({Nebulex.Adapters.Mnesia.ExpirationCheck, opts},
+        id: Nebulex.Adapters.Mnesia.ExpirationCheck
+      )
     ]
 
     child_spec = %{

--- a/lib/nebulex/adapters/mnesia.ex
+++ b/lib/nebulex/adapters/mnesia.ex
@@ -1,5 +1,7 @@
 defmodule Nebulex.Adapters.Mnesia do
-  alias __MODULE__.Table
+  alias __MODULE__.{ClusterCheck, Table}
+
+  require Logger
 
   @behaviour Nebulex.Adapter
   @behaviour Nebulex.Adapter.Queryable
@@ -9,8 +11,16 @@ defmodule Nebulex.Adapters.Mnesia do
   defmacro __before_compile__(_env), do: :ok
 
   @impl Nebulex.Adapter
-  def init(_opts) do
-    child_spec = Supervisor.child_spec({Agent, fn -> :ok end}, id: {Agent, 1})
+  def init(opts) do
+    children = [
+      Supervisor.child_spec(ClusterCheck, id: Mnesia.ClusterCheck),
+      Supervisor.child_spec({Nebulex.Adapters.Mnesia.ExpirationCheck, opts}, id: Nebulex.Adapters.Mnesia.ExpirationCheck)
+    ]
+
+    child_spec = %{
+      id: __MODULE__.Supervisor,
+      start: {Supervisor, :start_link, [children, [strategy: :one_for_one]]}
+    }
 
     check_cluster()
 
@@ -19,12 +29,39 @@ defmodule Nebulex.Adapters.Mnesia do
 
   def check_cluster do
     nodes = Node.list() ++ [Node.self()]
-    IO.puts("Setting up Mnesia schema on nodes: #{inspect(nodes)}")
 
     :mnesia.create_schema(nodes)
     :ok = :mnesia.start()
 
     Table.create_table(nodes)
+  end
+
+  @doc """
+  Scan the table and remove expired entries.
+  Returns the number of removed entries.
+  """
+  def clear_expired_keys do
+    case Table.expired_records() do
+      {:atomic, records} when is_list(records) ->
+        records
+        |> Enum.reduce(0, fn
+          {key, _value, _touched, _ttl}, acc ->
+            case Table.delete(key) do
+              :ok ->
+                acc + 1
+
+              _ ->
+                Logger.debug("Failed to delete expired key #{inspect(key)}")
+                acc
+            end
+
+          _other, acc ->
+            acc
+        end)
+
+      _other ->
+        0
+    end
   end
 
   @impl Nebulex.Adapter.Entry

--- a/lib/nebulex/adapters/mnesia/cluster_check.ex
+++ b/lib/nebulex/adapters/mnesia/cluster_check.ex
@@ -1,0 +1,27 @@
+defmodule Nebulex.Adapters.Mnesia.ClusterCheck do
+  use GenServer
+
+  alias Nebulex.Adapters.Mnesia
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, %{})
+  end
+
+  def init(state) do
+    schedule_check()
+
+    {:ok, state}
+  end
+
+  def schedule_check(time \\ 60_000) do
+    Process.send_after(self(), :check_cluster, time)
+  end
+
+  def handle_info(:check_cluster, state) do
+    Mnesia.check_cluster()
+
+    schedule_check()
+
+    {:noreply, state}
+  end
+end

--- a/lib/nebulex/adapters/mnesia/expiration_check.ex
+++ b/lib/nebulex/adapters/mnesia/expiration_check.ex
@@ -1,0 +1,33 @@
+defmodule Nebulex.Adapters.Mnesia.ExpirationCheck do
+  use GenServer
+
+  alias Nebulex.Adapters.Mnesia
+
+  @default_ttl 60_000
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  def init(opts) do
+    ttl = Keyword.get(opts, :ttl, @default_ttl)
+
+    schedule_check(ttl)
+
+    {:ok, opts}
+  end
+
+  def schedule_check(time) do
+    Process.send_after(self(), :clean_expired, time)
+  end
+
+  def handle_info(:clean_expired, state) do
+    ttl = Keyword.get(state, :ttl, @default_ttl)
+
+    Mnesia.clear_expired_keys()
+
+    schedule_check(ttl)
+
+    {:noreply, state}
+  end
+end

--- a/lib/nebulex/adapters/mnesia/table.ex
+++ b/lib/nebulex/adapters/mnesia/table.ex
@@ -147,4 +147,24 @@ defmodule Nebulex.Adapters.Mnesia.Table do
   defp cache_table do
     @default_table
   end
+
+  def expired_records do
+    today =
+      DateTime.utc_now()
+      |> DateTime.to_unix(:millisecond)
+
+    ms = [
+      {
+        {cache_table(), :"$1", :"$2", :"$3", :"$4"},
+        [
+          {:<, {:+, :"$3", :"$4"}, today}
+        ],
+        [{{:"$1", :"$2", :"$3", :"$4"}}]
+      }
+    ]
+
+    :mnesia.transaction(fn ->
+      :mnesia.select(cache_table(), ms)
+    end)
+  end
 end

--- a/test/nebulex_mnesia_adapter_test.exs
+++ b/test/nebulex_mnesia_adapter_test.exs
@@ -1,5 +1,5 @@
 defmodule NebulexMnesiaAdapterTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   use NebulexMnesiaAdapter.CacheTest
 
   alias NebulexMnesiaAdapter.TestCache, as: Cache


### PR DESCRIPTION
This code will add a simple GC process where the expired keys based on their ttl config will be removed from the cache tables.